### PR TITLE
Fix browser spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import ColorConverter from 'cie-colorconverter'
 
 ## Browser Usage
 
-The npm packages ships with a browser-ready version at `node_modules/cie-colorconvertor/dist.browser/browser.js`. This will expose a global variable at `window.CIEColorConvertor` and is used the same as the ES6 version.
+The npm packages ships with a browser-ready version at `node_modules/cie-colorconvertor/dist.browser/browser.js`. This will expose a global variable at `window.CIEColorConverter` and is used the same as the ES6 version.
 
 ## Convertor Options
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cie-colorconverter",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Convert between CIE color spaces",
   "main": "dist/index.js",
   "types": "types/index.d.ts",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,5 +1,5 @@
-import ColorConvertor from './index'
+import ColorConverter from './index'
 
 if (window) {
-  (<any>window).CIEColorConvertor = ColorConvertor;
+  (<any>window).CIEColorConverter = ColorConverter;
 }


### PR DESCRIPTION
Fix the spelling of converter in the browser component, and associated documentation. 

Because this is a breaking change, I've also updated the package version to 2.0.0

Note, this will apply cleanly against Master, but if you apply PR #2, it will create a conflict on a line where the spelling has already been fixed.