### PR TITLE
Use correct path for the types file for the module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "description": "Convert between CIE color spaces",
   "main": "dist/index.js",
-  "types": "types/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc && parcel build src/browser.ts --out-dir ./dist.browser",
     "test": "jest --verbose"


### PR DESCRIPTION
When using the NPM package in a TypeScript, the index.d.ts file was not correctly picked up. This fixes that issue